### PR TITLE
chore(release): prepare v8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.0.1](https://github.com/capacitor-community/volume-buttons/compare/v8.0.0...v8.0.1) (2026-07-24)
+
+### Bugfix
+
+- [iOS] prevent crashes by ensuring UIKit operations triggered by volume-button events run on the main thread ([#30](https://github.com/capacitor-community/volume-buttons/pull/30))
+
 ## [v8.0.0](https://github.com/capacitor-community/volume-buttons/compare/v7.0.0...v8.0.0) (2026-01-28)
 
 ### Chores

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This plugin contains code derived from or inspired by https://github.com/CipherB
 - keep receiving events after the application sent to and returns from the background
 - supports Android and iOS platforms
 
-**NOTE**: The plugin version 8.0.0 is compatible with Capacitor 8
+**NOTE**: The plugin version 8.x is compatible with Capacitor 8
 
 ## Plugin versions
 

--- a/example-app/android/app/build.gradle
+++ b/example-app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "ryltsov.alex.volume.buttons.demo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 800001
-        versionName "8.0.0"
+        versionCode 800101
+        versionName "8.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/example-app/ios/App/App.xcodeproj/project.pbxproj
+++ b/example-app/ios/App/App.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 8.0.0;
+				MARKETING_VERSION = 8.0.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = ryltsov.alex.volume.buttons.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -374,7 +374,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 8.0.0;
+				MARKETING_VERSION = 8.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ryltsov.alex.volume.buttons.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-app",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example-app",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "dependencies": {
         "@angular/animations": "^20.0.0",
         "@angular/common": "^20.0.0",
@@ -62,7 +62,7 @@
     },
     "..": {
       "name": "@capacitor-community/volume-buttons",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.2",

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": "Alex Ryltsov <ryltsov.alex@gmail.com>",
   "homepage": "https://github.com/capacitor-community/file-opener",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capacitor-community/volume-buttons",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capacitor-community/volume-buttons",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/volume-buttons",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Capacitor Volume Buttons. The plugin enables to listen to hardware volume button presses",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Changes:
- bump package and example app versions to 8.0.1
- update native project files and lockfiles
- document the iOS main-thread crash fix